### PR TITLE
Activation modes for service /ur_driver/robot_enable

### DIFF
--- a/include/ur_modern_driver/ros/service_stopper.h
+++ b/include/ur_modern_driver/ros/service_stopper.h
@@ -14,8 +14,8 @@ enum class RobotState
 
 enum class ActivationMode
 {
-  Always,
   Never,
+  Always,
   OnStartup
 };
 

--- a/include/ur_modern_driver/ros/service_stopper.h
+++ b/include/ur_modern_driver/ros/service_stopper.h
@@ -12,6 +12,13 @@ enum class RobotState
   ProtectiveStopped
 };
 
+enum class ActivationMode
+{
+  Always,
+  Never,
+  OnStartup
+};
+
 class Service
 {
 public:
@@ -25,6 +32,7 @@ private:
   ros::ServiceServer enable_service_;
   std::vector<Service*> services_;
   RobotState last_state_;
+  ActivationMode activation_mode_;
 
   void notify_all(RobotState state);
   bool handle(SharedRobotModeData& data, bool error);

--- a/launch/ur_common.launch
+++ b/launch/ur_common.launch
@@ -17,7 +17,7 @@
   <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
 
   <!-- require_activation defines when the service /ur_driver/robot_enable needs to be called. -->
-  <arg name="require_activation" default="Always" /> <!-- Always, Never, OnStartup -->
+  <arg name="require_activation" default="Never" /> <!-- Never, Always, OnStartup -->
     
   <!-- The max_velocity parameter is only used for debugging in the ur_driver. It's not related to actual velocity limits -->
   <arg name="max_velocity" default="10.0"/> <!-- [rad/s] -->

--- a/launch/ur_common.launch
+++ b/launch/ur_common.launch
@@ -15,6 +15,9 @@
   <arg name="servoj_time" default="0.008" />
   <arg name="base_frame" default="$(arg prefix)base" />
   <arg name="tool_frame" default="$(arg prefix)tool0_controller" />
+
+  <!-- require_activation defines when the service /ur_driver/robot_enable needs to be called. -->
+  <arg name="require_activation" default="Always" /> <!-- Always, Never, OnStartup -->
     
   <!-- The max_velocity parameter is only used for debugging in the ur_driver. It's not related to actual velocity limits -->
   <arg name="max_velocity" default="10.0"/> <!-- [rad/s] -->
@@ -30,7 +33,8 @@
     <param name="max_payload" type="double" value="$(arg max_payload)" />
     <param name="max_velocity" type="double" value="$(arg max_velocity)" />
     <param name="servoj_time" type="double" value="$(arg servoj_time)" />
-	<param name="base_frame" type="str" value="$(arg base_frame)"/>
+    <param name="base_frame" type="str" value="$(arg base_frame)"/>
     <param name="tool_frame" type="str" value="$(arg tool_frame)"/>
+    <param name="require_activation" type="str" value="$(arg require_activation)" />
   </node>
 </launch>

--- a/src/ros/service_stopper.cpp
+++ b/src/ros/service_stopper.cpp
@@ -4,26 +4,29 @@ ServiceStopper::ServiceStopper(std::vector<Service*> services)
   : enable_service_(nh_.advertiseService("ur_driver/robot_enable", &ServiceStopper::enableCallback, this))
   , services_(services)
   , last_state_(RobotState::Error)
-  , activation_mode_(ActivationMode::Always)
+  , activation_mode_(ActivationMode::Never)
 {
   std::string mode;
-  ros::param::param("~require_activation", mode, std::string("Always"));
-  if (mode == "Never")
+  ros::param::param("~require_activation", mode, std::string("Never"));
+  if (mode == "Always")
   {
-    activation_mode_ = ActivationMode::Never;
-    notify_all(RobotState::Running);
+    activation_mode_ = ActivationMode::Always;
   }
   else if (mode == "OnStartup")
   {
     activation_mode_ = ActivationMode::OnStartup;
   }
-  else if (mode != "Always")
+  else
   {
-    LOG_WARN("Found invalid value for param service_stopper_mode: '%s'\nShould be one of Always, Never, OnStartup", mode.c_str());
-    mode = "Always";
+    if (mode != "Never")
+    {
+      LOG_WARN("Found invalid value for param require_activation: '%s'\nShould be one of Never, OnStartup, Always", mode.c_str());
+      mode = "Never";
+    }
+    notify_all(RobotState::Running);
   }
 
-  LOG_INFO("ActivationMode mode: %s", mode.c_str());
+  LOG_INFO("Service 'ur_driver/robot_enable' activation mode: %s", mode.c_str());
 }
 
 bool ServiceStopper::enableCallback(std_srvs::EmptyRequest& req, std_srvs::EmptyResponse& resp)


### PR DESCRIPTION
This PR was implemented in collaboration with @v4hn.
A parameter _require_activation_ is added to configure when the `robot_enable` service has to be called to activate the driver. Prior this was required after every launch and emergency or protective stop. 

There are three modes now as [suggested](https://github.com/ThomasTimm/ur_modern_driver/pull/120#issuecomment-317050326) by @Zagitta in his [pull request](https://github.com/ThomasTimm/ur_modern_driver/pull/120):

- **Never** - the service is not required to be called at all (default)
- **Always** - the service has to be called after launch and every stop
- **OnStartup** - the service has to be called after launch only

Never is set as default value to maintain the default behaviour in indigo.
Setting Always/OnStartup as default would probably require modifying all launch files however. 
Enabling Always/OnStartup can be done by passing _require_activation_ to the `ur_common.launch` or by modifying corresponding launch files.
