### PR TITLE
Remove tcp_nodelay and add tcp_quickack in write and read

### DIFF
--- a/src/tcp_socket.cpp
+++ b/src/tcp_socket.cpp
@@ -18,7 +18,6 @@ TCPSocket::~TCPSocket()
 void TCPSocket::setOptions(int socket_fd)
 {
   int flag = 1;
-  setsockopt(socket_fd, IPPROTO_TCP, TCP_NODELAY, &flag, sizeof(int));
   setsockopt(socket_fd, IPPROTO_TCP, TCP_QUICKACK, &flag, sizeof(int));
 }
 
@@ -113,6 +112,9 @@ std::string TCPSocket::getIP()
 
 bool TCPSocket::read(uint8_t *buf, size_t buf_len, size_t &read)
 {
+  int flag = 1;
+  setsockopt(socket_fd_, IPPROTO_TCP, TCP_QUICKACK, &flag, sizeof(int));
+
   read = 0;
 
   if (state_ != SocketState::Connected)
@@ -134,6 +136,9 @@ bool TCPSocket::read(uint8_t *buf, size_t buf_len, size_t &read)
 
 bool TCPSocket::write(const uint8_t *buf, size_t buf_len, size_t &written)
 {
+  int flag = 1;
+  setsockopt(socket_fd_, IPPROTO_TCP, TCP_QUICKACK, &flag, sizeof(int));
+
   written = 0;
 
   if (state_ != SocketState::Connected)


### PR DESCRIPTION
Acording to http://man7.org/linux/man-pages/man7/tcp.7.html
quickack flag is NOT permanent.
As discussed in https://stackoverflow.com/questions/7286592/set-tcp-quickack-and-tcp-nodelay
tcp_nodelay should not be used.
In our usecase the robot did not jump with this fix and a low-latency
kernel.