### PR TITLE
Disable warnings after including controller_manager.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,8 @@ endif()
 add_compile_options(-Wall)
 add_compile_options(-Wextra)
 add_compile_options(-Wno-unused-parameter)
+add_compile_options(-Wno-ignored-qualifiers)
+add_compile_options(-Wno-return-type)
 
 # support indigo's ros_control - This can be removed upon EOL indigo
 if("${controller_manager_msgs_VERSION}" VERSION_LESS "0.10.0")


### PR DESCRIPTION
Those warnings are annoying, and since they come from ROS include, disabling them in CMakeLists.txt seems like a best approach.