### PR TITLE
Add time parameter to speedj for UR software >= 3.3

### DIFF
--- a/include/ur_modern_driver/ur/commander.h
+++ b/include/ur_modern_driver/ur/commander.h
@@ -49,7 +49,27 @@ public:
   {
   }
 
-  virtual bool speedj(std::array<double, 6> &speeds, double acceleration);
+  virtual bool speedj(std::array<double, 6> &speeds, double acceleration) = 0;
   virtual bool setDigitalOut(uint8_t pin, bool value);
   virtual bool setAnalogOut(uint8_t pin, double value);
+};
+
+class URCommander_V3_1__2 : public URCommander_V3_X
+{
+public:
+  URCommander_V3_1__2(URStream &stream) : URCommander_V3_X(stream)
+  {
+  }
+
+  virtual bool speedj(std::array<double, 6> &speeds, double acceleration);
+};
+
+class URCommander_V3_3 : public URCommander_V3_X
+{
+public:
+  URCommander_V3_3(URStream &stream) : URCommander_V3_X(stream)
+  {
+  }
+
+  virtual bool speedj(std::array<double, 6> &speeds, double acceleration);
 };

--- a/include/ur_modern_driver/ur/factory.h
+++ b/include/ur_modern_driver/ur/factory.h
@@ -80,8 +80,10 @@ public:
   {
     if (major_version_ == 1)
       return std::unique_ptr<URCommander>(new URCommander_V1_X(stream));
+    else if (minor_version_ < 3)
+      return std::unique_ptr<URCommander>(new URCommander_V3_1__2(stream));
     else
-      return std::unique_ptr<URCommander>(new URCommander_V3_X(stream));
+      return std::unique_ptr<URCommander>(new URCommander_V3_3(stream));
   }
 
   std::unique_ptr<URParser<StatePacket>> getStateParser()

--- a/src/ur/commander.cpp
+++ b/src/ur/commander.cpp
@@ -86,16 +86,6 @@ bool URCommander_V1_X::setDigitalOut(uint8_t pin, bool value)
   return write(s);
 }
 
-bool URCommander_V3_X::speedj(std::array<double, 6> &speeds, double acceleration)
-{
-  std::ostringstream out;
-  out << std::fixed << std::setprecision(5);
-  out << "speedj(";
-  formatArray(out, speeds);
-  out << "," << acceleration << ")\n";
-  std::string s(out.str());
-  return write(s);
-}
 bool URCommander_V3_X::setAnalogOut(uint8_t pin, double value)
 {
   std::ostringstream out;
@@ -127,6 +117,28 @@ bool URCommander_V3_X::setDigitalOut(uint8_t pin, bool value)
     return false;
 
   out << func << "(" << (int)pin << "," << (value ? "True" : "False") << ")\n";
+  std::string s(out.str());
+  return write(s);
+}
+
+bool URCommander_V3_1__2::speedj(std::array<double, 6> &speeds, double acceleration)
+{
+  std::ostringstream out;
+  out << std::fixed << std::setprecision(5);
+  out << "speedj(";
+  formatArray(out, speeds);
+  out << "," << acceleration << ")\n";
+  std::string s(out.str());
+  return write(s);
+}
+
+bool URCommander_V3_3::speedj(std::array<double, 6> &speeds, double acceleration)
+{
+  std::ostringstream out;
+  out << std::fixed << std::setprecision(5);
+  out << "speedj(";
+  formatArray(out, speeds);
+  out << "," << acceleration << "," << 0.008 << ")\n";
   std::string s(out.str());
   return write(s);
 }


### PR DESCRIPTION
Fixes #15 for me. Tested on a UR5 running CB 3.3.4.310, and PC running both Indigo/Trusty and Kinetic/Xenial.

Related to https://github.com/ThomasTimm/ur_modern_driver/issues/92