### PR TITLE
Add robot_state_publisher as a dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -68,6 +68,7 @@
   <run_depend>ur_description</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>std_srvs</run_depend>
+  <run_depend>robot_state_publisher</run_depend>
 
   <test_depend>rosunit</test_depend>
 


### PR DESCRIPTION
Adds robot_state_publisher to package.xml. The package is used in launch files and should be defined as a dependency.