### PR TITLE
Initialize VelocityInterface::prev_velocity_cmd_ with zeroes

### DIFF
--- a/src/ros/hardware_interface.cpp
+++ b/src/ros/hardware_interface.cpp
@@ -17,7 +17,6 @@ void JointInterface::update(RTShared &packet)
   efforts_ = packet.i_actual;
 }
 
-
 const std::string WrenchInterface::INTERFACE_NAME = "hardware_interface::ForceTorqueSensorInterface";
 WrenchInterface::WrenchInterface(std::string tcp_link)
 {
@@ -29,11 +28,10 @@ void WrenchInterface::update(RTShared &packet)
   tcp_ = packet.tcp_force;
 }
 
-
 const std::string VelocityInterface::INTERFACE_NAME = "hardware_interface::VelocityJointInterface";
 VelocityInterface::VelocityInterface(URCommander &commander, hardware_interface::JointStateInterface &js_interface,
                                      std::vector<std::string> &joint_names, double max_vel_change)
-  : commander_(commander), max_vel_change_(max_vel_change)
+  : commander_(commander), max_vel_change_(max_vel_change), prev_velocity_cmd_({ 0, 0, 0, 0, 0, 0 })
 {
   for (size_t i = 0; i < 6; i++)
   {


### PR DESCRIPTION
Without initializing `VelocityInterface::prev_velocity_cmd_`, the contents of the array are undefined, and [this](https://github.com/Zagitta/ur_modern_driver/blob/a9530c858617c6e54085f6718fca0f815b2965da/src/ros/hardware_interface.cpp#L52) may cause huge velocities when starting a controller, even if the generated command is all zeroes.